### PR TITLE
Get long tabs to have almost equal number of words

### DIFF
--- a/src/Theme.js
+++ b/src/Theme.js
@@ -147,6 +147,11 @@ const theme = createTheme({
     useNextVariants: true
   },
   overrides: {
+    MuiTab: {
+      wrapper: {
+        maxWidth: '11.2rem'
+      }
+    },
     MuiButton: {
       root: {
         border: '0.125rem solid #ffff',

--- a/src/components/ProfileTabs.js
+++ b/src/components/ProfileTabs.js
@@ -68,7 +68,10 @@ const styles = theme => ({
     }
   },
   tabSelected: {
-    fontWeight: 700
+    fontWeight: 700,
+    '& .MuiTab-wrapper': {
+      maxWidth: '11.8rem'
+    }
   },
   labelContainer: {
     paddingLeft: theme.spacing(2),


### PR DESCRIPTION
## Description

Split `Land traded statistic for transactions of colour` into two lines with equal number of words

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1131" alt="Screen Shot 2019-09-17 at 2 45 27 PM" src="https://user-images.githubusercontent.com/4308339/65039033-0115ca00-d95a-11e9-9c05-5a5c7c3bc1b9.png">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
