### PR TITLE
Improve mobile responsive of the site

### DIFF
--- a/src/Theme.js
+++ b/src/Theme.js
@@ -19,6 +19,15 @@ const COLOR_SCALE = [
 ];
 
 const theme = createTheme({
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 576,
+      md: 768,
+      lg: 1280,
+      xl: 1980
+    }
+  },
   chart: {
     colorScale: COLOR_SCALE,
     pie: {

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -89,6 +89,7 @@ const theme = createTheme({
     }
   },
   palette: {
+    background: { default: '#fff' },
     primary: { main: '#2b3129', light: '#f1f1ed', dark: '#222822' },
     secondary: { main: '#000000', dark: '#2c2c2a', grey: '#2b3129' },
     highlight: { main: '#e7e452' }

--- a/src/components/About/AboutCountry.js
+++ b/src/components/About/AboutCountry.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import Header from './Header';
 import Info, { InfoSubtitle, InfoBody } from './Info';
@@ -11,7 +10,7 @@ import Land from './Land';
 import land from '../../assets/images/hero-image-3.png';
 import config from '../../config';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: '#fff'
@@ -29,7 +28,7 @@ const styles = theme => ({
   imgGrid: {
     alignItems: 'flex-start',
     [theme.breakpoints.up('lg')]: {
-      alignItems: 'flex-end'
+      // alignItems: 'flex-end'
     }
   },
   info: {
@@ -43,17 +42,19 @@ const styles = theme => ({
       marginBottom: '3rem'
     }
   }
-});
+}));
 
-function AboutCountry({ classes, dominion }) {
+function AboutCountry({ dominion, ...props }) {
+  const classes = useStyles(props);
   const { selectedCountry = {} } = dominion;
   const info = config.about[selectedCountry.slug] || {
     intro: 'Not Found',
     other: 'Not found'
   };
+
   return (
     <div className={classes.root}>
-      <Grid container direction="row" className={classes.layout} spacing={4}>
+      <Grid container direction="row" className={classes.layout}>
         <Grid item md={4}>
           <Header>
             About <br />
@@ -77,8 +78,7 @@ function AboutCountry({ classes, dominion }) {
 }
 
 AboutCountry.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   dominion: PropTypes.shape({}).isRequired
 };
 
-export default withStyles(styles)(AboutCountry);
+export default AboutCountry;

--- a/src/components/About/AboutDominion.js
+++ b/src/components/About/AboutDominion.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import Header from './Header';
 import Info, { InfoSubtitle, InfoBody } from './Info';
@@ -12,7 +10,7 @@ import A from '../A';
 
 import land from '../../assets/images/hero-image-3_2.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: '#fff'
@@ -46,13 +44,15 @@ const styles = theme => ({
       order: 3
     }
   }
-});
+}));
 
-function AboutDominion({ classes }) {
+function AboutDominion({ ...props }) {
+  const classes = useStyles(props);
+
   return (
     <div className={classes.root}>
       <Grid container direction="row" className={classes.layout}>
-        <Grid item className={classes.header} md={3}>
+        <Grid item className={classes.header} md={4} lg={3}>
           <Header>
             About <br />
             Dominion
@@ -93,7 +93,7 @@ function AboutDominion({ classes }) {
             </InfoBody>
           </Info>
         </Grid>
-        <Grid container item className={classes.land} md={5}>
+        <Grid container item className={classes.land} md={4} lg={5}>
           <Land imgSrc={land} />
         </Grid>
       </Grid>
@@ -101,8 +101,4 @@ function AboutDominion({ classes }) {
   );
 }
 
-AboutDominion.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(AboutDominion);
+export default AboutDominion;

--- a/src/components/About/Header.js
+++ b/src/components/About/Header.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import withWidth from '@material-ui/core/withWidth';
+import { makeStyles, Typography } from '@material-ui/core';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: 'auto',
     padding: '1.43rem 2.143rem 0',
@@ -13,9 +11,11 @@ const styles = theme => ({
       padding: 0
     }
   }
-});
+}));
 
-function Header({ classes, children }) {
+function Header({ children, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <div className={classes.root}>
       <Typography variant="h2">{children}</Typography>
@@ -24,11 +24,10 @@ function Header({ classes, children }) {
 }
 
 Header.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-export default withWidth()(withStyles(styles)(Header));
+export default Header;

--- a/src/components/About/Info.js
+++ b/src/components/About/Info.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Typography } from '@material-ui/core';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     padding: '20px 30px',
     [theme.breakpoints.up('md')]: {
-      maxWidth: '21.875rem',
       paddingTop: 0,
       paddingLeft: '1rem',
       paddingRight: '2rem'
@@ -28,9 +26,11 @@ const styles = theme => ({
     marginTop: '1rem',
     lineHeight: 1.92
   }
-});
+}));
 
-function InfoSubtitleElement({ classes, children }) {
+function InfoSubtitle({ children, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Typography component="div" variant="body2" className={classes.subtitle}>
       {children}
@@ -38,17 +38,16 @@ function InfoSubtitleElement({ classes, children }) {
   );
 }
 
-InfoSubtitleElement.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+InfoSubtitle.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-export const InfoSubtitle = withStyles(styles)(InfoSubtitleElement);
+function InfoBody({ children, ...props }) {
+  const classes = useStyles(props);
 
-function InfoBodyElement({ classes, children }) {
   return (
     <Typography component="span" variant="body2" className={classes.body}>
       {children}
@@ -56,17 +55,18 @@ function InfoBodyElement({ classes, children }) {
   );
 }
 
-InfoBodyElement.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+InfoBody.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-export const InfoBody = withStyles(styles)(InfoBodyElement);
+export { InfoBody, InfoSubtitle };
 
-function Info({ classes, children }) {
+function Info({ children, ...props }) {
+  const classes = useStyles(props);
+
   return <div className={classes.root}>{children}</div>;
 }
 
@@ -78,4 +78,4 @@ Info.propTypes = {
   ]).isRequired
 };
 
-export default withStyles(styles)(Info);
+export default Info;

--- a/src/components/About/Land.js
+++ b/src/components/About/Land.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withWidth, Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, useMediaQuery, useTheme, Grid } from '@material-ui/core';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',
@@ -27,15 +26,20 @@ const styles = theme => ({
     }
   },
   highlight: {
-    width: '6.875rem', // 110px / 16
-    height: '1.25rem', // 20px
+    width: '6.875rem',
+    height: '1.25rem',
     background: '#e7e452'
   }
-});
+}));
 
-function Land({ classes, width, imgSrc }) {
-  const direction =
-    width === 'xs' || width === 'sm' ? 'column-reverse' : 'column';
+function Land({ width, imgSrc, ...props }) {
+  const classes = useStyles(props);
+  const theme = useTheme();
+  let direction = 'column';
+  if (useMediaQuery(theme.breakpoints.down('sm'))) {
+    direction = 'column-reverse';
+  }
+
   return (
     <Grid
       container
@@ -54,9 +58,8 @@ function Land({ classes, width, imgSrc }) {
 }
 
 Land.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   width: PropTypes.string.isRequired,
   imgSrc: PropTypes.string.isRequired
 };
 
-export default withWidth()(withStyles(styles)(Land));
+export default Land;

--- a/src/components/ArrowButton.js
+++ b/src/components/ArrowButton.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Button } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-
 import classNames from 'classnames';
 
-import arrowBlack from '../assets/images/icons/black-combined-shape.svg';
-import arrow from '../assets/images/icons/combined-shape.svg';
+import { makeStyles, Button, Grid } from '@material-ui/core';
 
-const styles = theme => ({
+import arrow from '../assets/images/icons/combined-shape.svg';
+import arrowBlack from '../assets/images/icons/black-combined-shape.svg';
+
+const useStyles = makeStyles(theme => ({
   root: {
     paddingTop: '2rem'
   },
@@ -35,13 +34,15 @@ const styles = theme => ({
   arrow: {
     pointerEvents: 'all',
     marginLeft: -theme.spacing(4),
-    [theme.breakpoints.down('sm')]: {
-      display: 'none'
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block'
     }
   }
-});
+}));
 
-function ArrowButton({ secondary, classes, children, onClick, ...props }) {
+function ArrowButton({ children, onClick, secondary, ...props }) {
+  const classes = useStyles(props);
   return (
     <Grid item sm={12} container alignItems="center" className={classes.root}>
       <Button
@@ -64,7 +65,6 @@ function ArrowButton({ secondary, classes, children, onClick, ...props }) {
 }
 
 ArrowButton.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -77,4 +77,4 @@ ArrowButton.defaultProps = {
   secondary: false
 };
 
-export default withStyles(styles)(ArrowButton);
+export default ArrowButton;

--- a/src/components/Card/Data.js
+++ b/src/components/Card/Data.js
@@ -1,17 +1,18 @@
 import React from 'react';
-
 import { PropTypes } from 'prop-types';
+
 import {
-  Grid,
-  Typography,
+  makeStyles,
   Card,
   CardActionArea,
-  CardContent
+  CardContent,
+  Grid,
+  Typography
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+
 import A from '../A';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     margin: '1.25rem 0'
@@ -25,10 +26,11 @@ const styles = theme => ({
     }
   },
   description: {
+    opacity: 0.6,
     marginTop: '0.625rem'
   },
   xsTitle: {
-    display: 'block',
+    marginTop: '1rem',
     [theme.breakpoints.up('md')]: {
       display: 'none'
     }
@@ -36,16 +38,24 @@ const styles = theme => ({
   mdTitle: {
     display: 'none',
     [theme.breakpoints.up('md')]: {
+      marginTop: '1rem',
       display: 'block'
     }
+  },
+  orgLink: {
+    opacity: 0.6
   }
-});
+}));
 
-function Data({ classes, orgLink, dataLink, title, description, preview }) {
+function Data({ orgLink, dataLink, title, description, preview, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Card className={classes.root}>
       <CardContent>
-        <A href={orgLink}>{orgLink}</A>
+        <A className={classes.orgLink} href={orgLink} underline="hover">
+          {orgLink}
+        </A>
         <CardActionArea target="_blank" href={dataLink}>
           <Typography className={classes.xsTitle} variant="h4">
             {title}
@@ -72,7 +82,6 @@ function Data({ classes, orgLink, dataLink, title, description, preview }) {
 }
 
 Data.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   orgLink: PropTypes.string.isRequired,
@@ -84,4 +93,4 @@ Data.defaultProps = {
   preview: null
 };
 
-export default withStyles(styles)(Data);
+export default Data;

--- a/src/components/Card/Document.js
+++ b/src/components/Card/Document.js
@@ -2,15 +2,15 @@ import React from 'react';
 
 import { PropTypes } from 'prop-types';
 import {
-  Grid,
-  Typography,
+  makeStyles,
   Card,
   CardActionArea,
-  CardContent
+  CardContent,
+  Grid,
+  Typography
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
 
-const styles = {
+const useStyles = makeStyles(() => ({
   root: {
     width: 'available'
   },
@@ -25,11 +25,14 @@ const styles = {
     padding: '0.625rem 0'
   },
   description: {
-    marginTop: '0.625rem'
+    marginTop: '0.625rem',
+    opacity: 0.6
   }
-};
+}));
 
-function Document({ classes, link, title, description, preview }) {
+function Document({ link, title, description, preview, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Card className={classes.root}>
       <CardActionArea target="_blank" href={link}>
@@ -41,7 +44,7 @@ function Document({ classes, link, title, description, preview }) {
 
             <Grid item xs={8} container direction="column" justify="center">
               <Typography variant="h5">{title}</Typography>
-              <Typography className={classes.description}>
+              <Typography variant="body2" className={classes.description}>
                 {description}
               </Typography>
             </Grid>
@@ -53,7 +56,6 @@ function Document({ classes, link, title, description, preview }) {
 }
 
 Document.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   link: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
@@ -64,4 +66,4 @@ Document.defaultProps = {
   preview: null
 };
 
-export default withStyles(styles)(Document);
+export default Document;

--- a/src/components/CountryPartners/PartnerContent.js
+++ b/src/components/CountryPartners/PartnerContent.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Typography } from '@material-ui/core';
 
-const styles = () => ({
+const useStyles = makeStyles(() => ({
   root: {
     flexGrow: 1
   },
@@ -12,9 +11,11 @@ const styles = () => ({
     paddingBottom: '1rem',
     color: '#293229'
   }
-});
+}));
 
-function PartnerText({ classes, title, description }) {
+function PartnerText({ title, description, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <div className={classes.root}>
       <Typography variant="h4" className={classes.title}>
@@ -26,9 +27,8 @@ function PartnerText({ classes, title, description }) {
 }
 
 PartnerText.propTypes = {
-  classes: PropTypes.shape().isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired
 };
 
-export default withStyles(styles)(PartnerText);
+export default PartnerText;

--- a/src/components/CountryPartners/index.js
+++ b/src/components/CountryPartners/index.js
@@ -1,8 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import PartnerContent from './PartnerContent';
 
@@ -13,7 +12,7 @@ import ourland from '../../assets/images/logos/onground.png';
 import landbou from '../../assets/images/logos/landbou.png';
 import citypress from '../../assets/images/logos/citypress.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexRow: 1,
     backgroundColor: theme.palette.primary.light
@@ -28,8 +27,11 @@ const styles = theme => ({
   img: {
     maxHeight: '6.88rem',
     maxWidth: '30vw',
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('sm')]: {
       width: 'auto',
+      maxWidth: '8vw'
+    },
+    [theme.breakpoints.up('lg')]: {
       maxWidth: '11.423rem'
     }
   },
@@ -40,14 +42,22 @@ const styles = theme => ({
     }
   },
   imageGrid: {
-    padding: '1.143rem',
-    [theme.breakpoints.up('md')]: {
+    textAlign: 'center',
+    width: '100%',
+    padding: '0.75rem',
+    [theme.breakpoints.up('sm')]: {
+      textAlign: 'left',
+      width: 'auto'
+    },
+    [theme.breakpoints.up('lg')]: {
       padding: '2.286rem 1.143rem'
     }
   }
-});
+}));
 
-function CountryPartners({ classes, dominion: { selectedCountry } }) {
+function CountryPartners({ dominion: { selectedCountry }, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Grid className={classes.root}>
       <Grid
@@ -68,7 +78,6 @@ function CountryPartners({ classes, dominion: { selectedCountry } }) {
           item
           xs={12}
           sm={8}
-          spacing={6}
           container
           direction="row"
           justify="flex-start"
@@ -90,7 +99,7 @@ function CountryPartners({ classes, dominion: { selectedCountry } }) {
           {((selectedCountry && selectedCountry.slug === 'south-africa') ||
             selectedCountry === null) && (
             <Fragment>
-              <Grid item className={classes.imageGrid}>
+              <Grid className={classes.imageGrid} item>
                 <A href="http://africauncensored.net/about/">
                   <img
                     src={citypress}
@@ -141,10 +150,9 @@ CountryPartners.defaultProps = {
 };
 
 CountryPartners.propTypes = {
-  classes: PropTypes.shape().isRequired,
   dominion: PropTypes.shape({
     selectedCountry: PropTypes.object
   })
 };
 
-export default withStyles(styles)(CountryPartners);
+export default CountryPartners;

--- a/src/components/Data/Content.js
+++ b/src/components/Data/Content.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import A from '../A';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     textAlign: 'left',
+    [theme.breakpoints.up('md')]: {
+      width: '11rem'
+    },
     [theme.breakpoints.up('lg')]: {
       width: '21.45rem'
-    },
-    [theme.breakpoints.up('md')]: {
-      width: '15rem'
     }
   },
   title: {
@@ -54,18 +53,20 @@ const styles = theme => ({
       paddingTop: '2.7rem'
     }
   }
-});
+}));
 
 function Content({
   children,
-  classes,
   title,
   contentCount,
   contentType,
   description,
   link,
-  target
+  target,
+  ...props
 }) {
+  const classes = useStyles(props);
+
   return (
     <Grid className={classes.root}>
       <Grid item xs={12}>
@@ -109,7 +110,6 @@ Content.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
-  classes: PropTypes.shape().isRequired,
   title: PropTypes.string.isRequired,
   contentCount: PropTypes.string.isRequired,
   contentType: PropTypes.string.isRequired,
@@ -122,4 +122,4 @@ Content.defaultProps = {
   target: '_blank'
 };
 
-export default withStyles(styles)(Content);
+export default Content;

--- a/src/components/Data/Content.js
+++ b/src/components/Data/Content.js
@@ -41,8 +41,10 @@ const useStyles = makeStyles(theme => ({
   },
   contentText: {
     paddingTop: '1rem',
+    width: '80%',
     [theme.breakpoints.up('md')]: {
-      height: '4.76rem'
+      height: '4.76rem',
+      width: 'auto'
     }
   },
   link: { textDecoration: 'none' },

--- a/src/components/Data/DatasetsContent.js
+++ b/src/components/Data/DatasetsContent.js
@@ -1,22 +1,23 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 
-import plugicon from '../../assets/images/icons/group-6.png';
+import { makeStyles } from '@material-ui/core';
+
+import plugIcon from '../../assets/images/icons/group-6.png';
 
 import Content from './Content';
 import { getOpenAfricaDominionGroupData } from '../../lib/api';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     marginTop: '3rem',
     [theme.breakpoints.up('md')]: {
       marginTop: 0
     }
   }
-});
+}));
 
-function DataSetsContent({ classes }) {
+function DataSetsContent(props) {
+  const classes = useStyles(props);
   const [datasetsCount, setDatasetsCount] = useState('-');
 
   useEffect(() => {
@@ -37,14 +38,10 @@ function DataSetsContent({ classes }) {
         target="_self"
         link="/resources#data"
       >
-        <img src={plugicon} alt="Plug Icon" />
+        <img src={plugIcon} alt="Plug Icon" />
       </Content>
     </div>
   );
 }
 
-DataSetsContent.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(DataSetsContent);
+export default DataSetsContent;

--- a/src/components/Data/DatasetsContent.js
+++ b/src/components/Data/DatasetsContent.js
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 
 import { makeStyles } from '@material-ui/core';
 
-import plugIcon from '../../assets/images/icons/group-6.png';
-
-import Content from './Content';
 import { getOpenAfricaDominionGroupData } from '../../lib/api';
+import Content from './Content';
+
+import plugIcon from '../../assets/images/icons/group-6.png';
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/src/components/Data/DocumentsContents.js
+++ b/src/components/Data/DocumentsContents.js
@@ -1,16 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import menuicon from '../../assets/images/icons/group-7.png';
-import Content from './Content';
+
 import { getSourceAfricaDominionData } from '../../lib/api';
+import Content from './Content';
+
+import menuIcon from '../../assets/images/icons/group-7.png';
 
 function DocumentsContent() {
   const [documentsCount, setDocumentsCount] = useState('-');
-
   useEffect(() => {
     getSourceAfricaDominionData().then(({ data: { documents } }) => {
       setDocumentsCount(documents.length);
     });
   }, []);
+
   return (
     <Content
       title="sourceAFRICA"
@@ -23,7 +25,7 @@ function DocumentsContent() {
       target="_self"
       link="/resources#documents"
     >
-      <img src={menuicon} alt="Menu Icon" />
+      <img src={menuIcon} alt="Menu Icon" />
     </Content>
   );
 }

--- a/src/components/Data/index.js
+++ b/src/components/Data/index.js
@@ -1,24 +1,28 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid, Hidden } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-import DocumentsContent from './DocumentsContents';
+import { makeStyles, Grid, Hidden } from '@material-ui/core';
+
 import DatasetsContent from './DatasetsContent';
+import DocumentsContent from './DocumentsContents';
 
-import databg from '../../assets/images/bg/databg.png';
 import background from '../../assets/images/kaitlyn-baker-422999-unsplash.png';
+import dataBackground from '../../assets/images/bg/databg.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: '#fff',
-    backgroundImage: `url(${databg})`,
+    backgroundImage: `url(${dataBackground})`,
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'top left',
     backgroundSize: '80% 70%',
     marginBottom: '4.57rem',
     [theme.breakpoints.up('md')]: {
+      backgroundSize: '69% 100%',
+      paddingLeft: 0, // 30px / 16
+      marginBottom: '9.143rem'
+    },
+    [theme.breakpoints.up('lg')]: {
       paddingLeft: 0, // 30px / 16
       backgroundSize: '65% 100%',
       marginBottom: '9.143rem'
@@ -50,6 +54,9 @@ const styles = theme => ({
     height: '2.858rem',
     background: '#e7e452',
     [theme.breakpoints.up('md')]: {
+      width: '16.6285rem' // 60% of img
+    },
+    [theme.breakpoints.up('lg')]: {
       width: '24.286rem' // 340px / 16
     }
   },
@@ -59,8 +66,11 @@ const styles = theme => ({
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
     [theme.breakpoints.up('md')]: {
-      width: '37.7143rem', // .75 of lg
-      height: '28.5714rem' // 400px / 16
+      width: '27.7143rem',
+      height: '28.5714rem'
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '37.7143rem'
     }
   },
   imageHighlight: {
@@ -85,28 +95,20 @@ const styles = theme => ({
       marginTop: 0
     }
   }
-});
+}));
 
-function Data({ classes }) {
+function Data(props) {
+  const classes = useStyles(props);
+
   return (
     <div className={classes.root}>
-      <Grid container direction="row" className={classes.wrapper}>
-        <Grid
-          container
-          direction="row"
-          item
-          md={9}
-          lg={9}
-          xl={9}
-          className={classes.dataWrapper}
-        >
+      <Grid container className={classes.wrapper}>
+        <Grid item md={9} container className={classes.dataWrapper}>
           <Hidden smDown>
             <Grid
               item
-              container
               md={8}
-              lg={8}
-              xl={8}
+              container
               direction="column"
               className={classes.imageHighlight}
             >
@@ -118,14 +120,7 @@ function Data({ classes }) {
             <DocumentsContent />
           </Grid>
         </Grid>
-        <Grid
-          container
-          item
-          md={3}
-          lg={3}
-          xl={3}
-          className={classes.datasetData}
-        >
+        <Grid item md={4} lg={3} container className={classes.datasetData}>
           <DatasetsContent />
         </Grid>
       </Grid>
@@ -133,8 +128,4 @@ function Data({ classes }) {
   );
 }
 
-Data.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(Data);
+export default Data;

--- a/src/components/Data/index.js
+++ b/src/components/Data/index.js
@@ -15,7 +15,8 @@ const useStyles = makeStyles(theme => ({
     backgroundImage: `url(${dataBackground})`,
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'top left',
-    backgroundSize: '80% 70%',
+    backgroundSize: '65% 75%',
+    marginTop: '5rem',
     marginBottom: '4.57rem',
     [theme.breakpoints.up('md')]: {
       backgroundSize: '69% 100%',
@@ -116,7 +117,7 @@ function Data(props) {
               <div className={classes.img} />
             </Grid>
           </Hidden>
-          <Grid item md={4} lg={4} xl={4} className={classes.documentData}>
+          <Grid item md={4} lg={4} className={classes.documentData}>
             <DocumentsContent />
           </Grid>
         </Grid>

--- a/src/components/Footer/About.js
+++ b/src/components/Footer/About.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Typography } from '@material-ui/core';
 
 import A from '../A';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     [theme.breakpoints.up('md')]: {
@@ -43,9 +41,11 @@ const styles = theme => ({
     color: theme.palette.primary.light,
     opacity: '0.6'
   }
-});
+}));
 
-function About({ classes }) {
+function About(props) {
+  const classes = useStyles(props);
+
   return (
     <div>
       <Typography variant="subtitle1" className={classes.title}>
@@ -118,8 +118,5 @@ function About({ classes }) {
     </div>
   );
 }
-About.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
 
-export default withStyles(styles)(About);
+export default About;

--- a/src/components/Footer/Community.js
+++ b/src/components/Footer/Community.js
@@ -1,24 +1,34 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
-import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Typography } from '@material-ui/core';
 
 import A from '../A';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
-    width: '7.125rem', // 114px / 16
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      width: '7rem'
+    },
     [theme.breakpoints.up('md')]: {
+      width: '11rem'
+    },
+    [theme.breakpoints.up('lg')]: {
       width: '12.5625rem' // 201px
     }
   },
   listText: {
     // match parent width
-    width: '7.125rem',
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      width: '7rem'
+    },
     [theme.breakpoints.up('md')]: {
+      width: '11rem'
+    },
+    [theme.breakpoints.up('lg')]: {
       width: '12.5625rem' // 201px
     },
     color: theme.palette.primary.light,
@@ -35,10 +45,12 @@ const styles = theme => ({
   joinText: {
     paddingTop: '1.5rem'
   }
-});
+}));
 
-function Community({ classes }) {
+function Community(props) {
+  const classes = useStyles(props);
   const joinClassName = classNames(classes.listText, classes.joinText);
+
   return (
     <div classes={classes.root}>
       <Typography
@@ -79,8 +91,5 @@ function Community({ classes }) {
     </div>
   );
 }
-Community.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
 
-export default withStyles(styles)(Community);
+export default Community;

--- a/src/components/Footer/Project.js
+++ b/src/components/Footer/Project.js
@@ -1,18 +1,22 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import A from '../A';
 import SocialMedia from '../SocialMedia';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     height: '100%',
-    width: '9.75rem', // 156px / 16
+    width: '100%', // 156px / 16
+    [theme.breakpoints.up('sm')]: {
+      width: '7rem'
+    },
     [theme.breakpoints.up('md')]: {
+      width: '7.5rem'
+    },
+    [theme.breakpoints.up('lg')]: {
       width: '12.5625rem' // 201px / 16
     }
   },
@@ -31,9 +35,11 @@ const styles = theme => ({
   joinText: {
     paddingTop: '1.5rem'
   }
-});
+}));
 
-function Community({ classes }) {
+function Community(props) {
+  const classes = useStyles(props);
+
   return (
     <Grid container className={classes.root} justify="flex-start">
       <Grid item xs={12}>
@@ -65,8 +71,5 @@ function Community({ classes }) {
     </Grid>
   );
 }
-Community.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
 
-export default withStyles(styles)(Community);
+export default Community;

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import About from './About';
 import Community from './Community';
@@ -10,19 +8,21 @@ import Project from './Project';
 
 import background from '../../assets/images/bg/background.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundImage: `url(${background})`,
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
     paddingTop: '3.64rem',
-    paddingLeft: '2.143rem',
+    paddingRight: '1.25rem',
     paddingBottom: '3.286rem',
-    [theme.breakpoints.up('md')]: {
+    paddingLeft: '1.875rem',
+    [theme.breakpoints.up('sm')]: {
       paddingTop: '6rem',
-      paddingLeft: 0,
-      paddingBottom: '3.857rem'
+      paddingRight: 0,
+      paddingBottom: '3.857rem',
+      paddingLeft: 0
     }
   },
   layout: {
@@ -38,30 +38,51 @@ const styles = theme => ({
   },
   organisation: {
     width: '100%',
-    marginTop: '1.857rem', // 26px / 16
-    [theme.breakpoints.up('md')]: {
+    marginTop: '1.857rem',
+    [theme.breakpoints.up('sm')]: {
+      justifyContent: 'flex-start',
       width: 'auto',
       marginTop: 0
+    },
+    [theme.breakpoints.up('md')]: {
+      justifyContent: 'flex-end'
     }
   },
-  community: {}
-});
+  community: {
+    width: '50%',
+    [theme.breakpoints.up('sm')]: {
+      width: 'auto'
+    }
+  },
+  project: {
+    width: '50%',
+    [theme.breakpoints.up('sm')]: {
+      width: 'auto'
+    }
+  }
+}));
 
-function Footer({ classes }) {
+function Footer(props) {
+  const classes = useStyles(props);
+
   return (
-    <Grid className={classes.root}>
-      <Grid container className={classes.layout} direction="row">
-        <Grid item xs={7} className={classes.about}>
+    <Grid container className={classes.root}>
+      <Grid
+        item
+        xs={12}
+        container
+        alignItems="flex-start"
+        className={classes.layout}
+      >
+        <Grid item xs={12} sm={7} className={classes.about}>
           <About />
         </Grid>
-        <Grid item xs={5} className={classes.organisation}>
-          <Grid container justify="flex-end">
-            <Grid item className={classes.community}>
-              <Community />
-            </Grid>
-            <Grid item>
-              <Project />
-            </Grid>
+        <Grid item xs={12} sm={5} container className={classes.organisation}>
+          <Grid item className={classes.community}>
+            <Community />
+          </Grid>
+          <Grid item className={classes.project}>
+            <Project />
           </Grid>
         </Grid>
       </Grid>
@@ -69,8 +90,4 @@ function Footer({ classes }) {
   );
 }
 
-Footer.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(Footer);
+export default Footer;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,19 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-
 import { withRouter } from 'react-router-dom';
 
-import withWidth from '@material-ui/core/withWidth';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import Navigation from './Navigation';
 
 import background from '../../assets/images/bg/background.png';
 import useCloseModalOnPopstate from '../../useCloseModalOnPopstate';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundImage: `url(${background})`,
@@ -37,10 +34,12 @@ const styles = theme => ({
     position: 'relative',
     width: '100%'
   }
-});
+}));
 
-function Header({ classes, history, children, dominion, ...props }) {
+function Header({ history, children, dominion, ...props }) {
+  const classes = useStyles(props);
   useCloseModalOnPopstate();
+
   return (
     <div className={classes.root}>
       <Grid container className={classes.wrapper}>
@@ -56,7 +55,6 @@ function Header({ classes, history, children, dominion, ...props }) {
 }
 
 Header.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -64,4 +62,4 @@ Header.propTypes = {
   dominion: PropTypes.shape({}).isRequired
 };
 
-export default withRouter(withWidth()(withStyles(styles)(Header)));
+export default withRouter(Header);

--- a/src/components/Header/Navigation.js
+++ b/src/components/Header/Navigation.js
@@ -1,26 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Link, MenuList, MenuItem, IconButton } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+  Grid,
+  IconButton,
+  Link,
+  MenuItem,
+  MenuList
+} from '@material-ui/core';
 
-import withWidth, { isWidthDown } from '@material-ui/core/withWidth';
+import useToggleModal from '../../useToggleModal';
+import ContactUs from '../Modal/ContactUs';
+import Dropdown, { CountriesButton } from './PortalDropdown';
+import Modal from '../Modal';
+import PortalChooser from '../Modal/PortalChooser';
+import Search from '../Search';
+
+import backIcon from '../../assets/images/icons/back.svg';
 import logo from '../../assets/images/logos/dominion-logo.png';
 import logoWithCountrySpace from '../../assets/images/logos/dominion-logo-country.png';
-import Dropdown, { CountriesButton } from './PortalDropdown';
-
-import Search from '../Search';
-import PortalChooser from '../Modal/PortalChooser';
-import ContactUs from '../Modal/ContactUs';
-
 import menuIcon from '../../assets/images/icons/menu.svg';
-import backIcon from '../../assets/images/icons/back.svg';
 import searchIcon from '../../assets/images/icons/location.svg';
 
-import Modal from '../Modal';
-import useToggleModal from '../../useToggleModal';
-
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1
   },
@@ -47,9 +52,9 @@ const styles = theme => ({
   },
   topMenuIcon: {
     color: 'white',
-    display: 'none',
-    [theme.breakpoints.down('sm')]: {
-      display: 'inline-block'
+    display: 'inline-block',
+    [theme.breakpoints.up('md')]: {
+      display: 'none'
     }
   },
   topMenuIconImg: {
@@ -101,9 +106,11 @@ const styles = theme => ({
     fontSize: 'x-small',
     textTransform: 'uppercase'
   }
-});
+}));
 
-function Navigation({ classes, width, dominion }) {
+function Navigation({ dominion, ...props }) {
+  const classes = useStyles(props);
+  const theme = useTheme();
   const { countries, selectedCountry } = dominion;
   const { open: openPortal, toggleModal: togglePortal } = useToggleModal(
     'portal'
@@ -231,9 +238,9 @@ function Navigation({ classes, width, dominion }) {
     </Grid>
   );
 
-  const nav = isWidthDown('sm', width)
-    ? renderMobileMenu()
-    : renderDesktopMenu();
+  const nav = useMediaQuery(theme.breakpoints.up('md'))
+    ? renderDesktopMenu()
+    : renderMobileMenu();
 
   return (
     <React.Fragment>
@@ -263,9 +270,7 @@ function Navigation({ classes, width, dominion }) {
 }
 
 Navigation.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
-  width: PropTypes.string.isRequired,
   dominion: PropTypes.shape({}).isRequired
 };
 
-export default withWidth()(withStyles(styles)(Navigation));
+export default Navigation;

--- a/src/components/Hero/CountryHero.js
+++ b/src/components/Hero/CountryHero.js
@@ -1,27 +1,32 @@
 import React, { useCallback } from 'react';
-
 import { PropTypes } from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { MapIt } from '@codeforafrica/hurumap-ui';
-import { Typography } from '@material-ui/core';
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
+
 import { withRouter } from 'react-router-dom';
 
-import Hero, {
-  HeroTitle,
-  HeroDescription,
-  HeroTitleGrid,
-  HeroButton
-} from './Hero';
+import {
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+  Typography
+} from '@material-ui/core';
+
+import { MapIt } from '@codeforafrica/hurumap-ui';
+
 import config from '../../config';
 import useToggleModal from '../../useToggleModal';
+import Hero, {
+  HeroButton,
+  HeroDescription,
+  HeroTitle,
+  HeroTitleGrid
+} from './Hero';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
-    marginTop: '32px',
+    marginTop: '2rem',
     [theme.breakpoints.up('md')]: {
-      marginBottom: '80px'
+      marginBottom: '5rem'
     }
   },
   titleGrid: {
@@ -31,19 +36,24 @@ const styles = theme => ({
     }
   },
   countryName: {
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('lg')]: {
       whiteSpace: 'nowrap'
     }
   },
   description: {
-    [theme.breakpoints.up('md')]: {
-      whiteSpace: 'nowrap',
-      width: '100%'
+    [theme.breakpoints.up('lg')]: {
+      whiteSpace: 'nowrap'
     }
   },
   alink: {
     color: '#e7e452',
     pointerEvents: 'all'
+  },
+  heroButtonArray: {
+    display: 'none',
+    [theme.breakpoints.up('lg')]: {
+      display: 'block'
+    }
   },
   map: {
     zIndex: 0,
@@ -60,9 +70,11 @@ const styles = theme => ({
       maxWidth: '51.8125rem !important'
     }
   }
-});
+}));
 
-function CountryHero({ classes, width, history, dominion }) {
+function CountryHero({ history, dominion, ...props }) {
+  const classes = useStyles(props);
+  const theme = useTheme();
   const { selectedCountry = { name: '' } } = dominion;
   const { toggleModal } = useToggleModal('search');
   const onClickGeoLayer = useCallback(
@@ -71,6 +83,7 @@ function CountryHero({ classes, width, history, dominion }) {
     },
     [history]
   );
+
   return (
     <Hero classes={{ root: classes.root }}>
       <HeroTitleGrid classes={{ titleTextGrid: classes.titleGrid }}>
@@ -79,11 +92,16 @@ function CountryHero({ classes, width, history, dominion }) {
         </HeroTitle>
         <HeroDescription classes={{ body2: classes.description }}>
           Dominion gives you the data to add context and authority to{' '}
-          {isWidthUp('md', width) && <br />}
+          {useMediaQuery(theme.breakpoints.up('md')) && <br />}
           public discourse and policy-making on vital issues of land ownership.
         </HeroDescription>
 
-        <HeroButton onClick={toggleModal}>Find a place</HeroButton>
+        <HeroButton
+          classes={{ arrow: classes.heroButtonArray }}
+          onClick={toggleModal}
+        >
+          Find a place
+        </HeroButton>
 
         <Typography variant="subtitle2" style={{ marginTop: '2.5rem' }}>
           or view{' '}
@@ -111,9 +129,7 @@ function CountryHero({ classes, width, history, dominion }) {
 }
 
 CountryHero.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
-  dominion: PropTypes.shape({}).isRequired,
-  width: PropTypes.string.isRequired
+  dominion: PropTypes.shape({}).isRequired
 };
 
-export default withRouter(withWidth()(withStyles(styles)(CountryHero)));
+export default withRouter(CountryHero);

--- a/src/components/Hero/Hero.js
+++ b/src/components/Hero/Hero.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 
+import { makeStyles, Grid, Typography } from '@material-ui/core';
+
 import { ContentLoader } from '@codeforafrica/hurumap-ui';
+
 import ArrowButton from '../ArrowButton';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     pointerEvents: 'all',
@@ -70,13 +71,13 @@ const styles = theme => ({
     pointerEvents: 'all',
     color: 'white',
     textAlign: 'left',
-    width: '80%',
+    width: '100%',
     paddingTop: '2rem',
     opacity: '0.8',
     fontSize: '0.786rem',
     lineHeight: 2.09,
-    [theme.breakpoints.down('sm')]: {
-      width: '100%'
+    [theme.breakpoints.up('md')]: {
+      width: '80%'
     }
   },
   detailComponent: {
@@ -85,17 +86,17 @@ const styles = theme => ({
     paddingTop: theme.spacing(),
     paddingBottom: theme.spacing()
   }
-});
+}));
 
-function HeroTitleGridComponent({ classes, children, quater, head2head }) {
+function HeroTitleGrid({ children, quarter, head2head, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Grid
       container
       item
       xs={12}
-      sm={12}
-      md={quater ? 4 : 8}
-      lg={quater ? 4 : 8}
+      md={quarter ? 4 : 8}
       wrap="nowrap"
       direction="column"
       alignContent="center"
@@ -108,31 +109,30 @@ function HeroTitleGridComponent({ classes, children, quater, head2head }) {
   );
 }
 
-HeroTitleGridComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+HeroTitleGrid.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
-  quater: PropTypes.bool,
+  quarter: PropTypes.bool,
   head2head: PropTypes.bool
 };
 
-HeroTitleGridComponent.defaultProps = {
-  quater: false,
+HeroTitleGrid.defaultProps = {
+  quarter: false,
   head2head: false
 };
 
-const HeroTitleGrid = withStyles(styles)(HeroTitleGridComponent);
-
-function HeroTitleComponent({
-  classes,
+function HeroTitle({
   loaderWidth,
   loading,
   children,
   breakWord,
-  small
+  small,
+  ...props
 }) {
+  const classes = useStyles(props);
+
   if (loading) {
     return (
       <ContentLoader style={{ width: loaderWidth, height: 100 }}>
@@ -155,8 +155,7 @@ function HeroTitleComponent({
   );
 }
 
-HeroTitleComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+HeroTitle.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -167,16 +166,16 @@ HeroTitleComponent.propTypes = {
   loaderWidth: PropTypes.oneOf([PropTypes.number, PropTypes.string])
 };
 
-HeroTitleComponent.defaultProps = {
+HeroTitle.defaultProps = {
   breakWord: false,
   small: false,
   loading: false,
   loaderWidth: '100%'
 };
 
-const HeroTitle = withStyles(styles)(HeroTitleComponent);
+function HeroDescription({ children, ...props }) {
+  const classes = useStyles(props);
 
-function HeroDescriptionComponent({ classes, children }) {
   return (
     <Typography variant="body1" className={classes.body2}>
       {children}
@@ -184,25 +183,23 @@ function HeroDescriptionComponent({ classes, children }) {
   );
 }
 
-HeroDescriptionComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+HeroDescription.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-const HeroDescription = withStyles(styles)(HeroDescriptionComponent);
-
-function HeroDetailComponent({
-  classes,
+function HeroDetail({
   hidden,
   loading,
   children,
   label,
   small,
-  loader
+  loader,
+  ...props
 }) {
+  const classes = useStyles(props);
   if (hidden) {
     return null;
   }
@@ -251,8 +248,7 @@ function HeroDetailComponent({
   );
 }
 
-HeroDetailComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+HeroDetail.propTypes = {
   children: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   small: PropTypes.bool.isRequired,
@@ -266,7 +262,7 @@ HeroDetailComponent.propTypes = {
   })
 };
 
-HeroDetailComponent.defaultProps = {
+HeroDetail.defaultProps = {
   loading: false,
   hidden: false,
   loader: {
@@ -275,18 +271,15 @@ HeroDetailComponent.defaultProps = {
   }
 };
 
-const HeroDetail = withStyles(styles)(HeroDetailComponent);
-
-function HeroButtonComponent({ children, onClick }) {
+function HeroButton({ children, onClick, ...props }) {
   return (
-    <ArrowButton secondary onClick={onClick}>
+    <ArrowButton secondary onClick={onClick} {...props}>
       {children}
     </ArrowButton>
   );
 }
 
-HeroButtonComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+HeroButton.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -294,9 +287,9 @@ HeroButtonComponent.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
-const HeroButton = withStyles(styles)(HeroButtonComponent);
+function Hero({ children, ...props }) {
+  const classes = useStyles(props);
 
-function HeroComponent({ classes, children, ...props }) {
   return (
     <Grid container className={classes.root} {...props}>
       {children}
@@ -304,16 +297,12 @@ function HeroComponent({ classes, children, ...props }) {
   );
 }
 
-HeroComponent.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
+Hero.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-const Hero = withStyles(styles)(HeroComponent);
-
-export default Hero;
-
 export { HeroTitle, HeroDescription, HeroButton, HeroTitleGrid, HeroDetail };
+export default Hero;

--- a/src/components/Hero/HomeHero.js
+++ b/src/components/Hero/HomeHero.js
@@ -1,53 +1,53 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
-import Hero, {
-  HeroTitle,
-  HeroDescription,
-  HeroTitleGrid,
-  HeroButton
-} from './Hero';
-
-import herobg from '../../assets/images/bg/hero_bg.png';
-import smallscreenbackground from '../../assets/images/bg/smallscreen_background.png';
-
-import HomeHeroMap from './HomeHeroMap';
 import useToggleModal from '../../useToggleModal';
+import Hero, {
+  HeroButton,
+  HeroDescription,
+  HeroTitle,
+  HeroTitleGrid
+} from './Hero';
+import HomeHeroMap from './HomeHeroMap';
 
-const styles = theme => ({
+import heroBg from '../../assets/images/bg/hero_bg.png';
+import smallScreenBackground from '../../assets/images/bg/smallscreen_background.png';
+
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1
   },
   heroContentGrid: {
     flexGrow: 1,
-    backgroundImage: `url(${herobg})`,
+    backgroundImage: `url(${smallScreenBackground})`,
+    backgroundPosition: 'right top',
     backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
     backgroundSize: 'auto',
     width: '100%',
     height: 'auto',
-    padding: '4rem 0',
+    padding: 0,
     marginTop: '2rem',
-    marginBottom: '6rem',
-    [theme.breakpoints.down('sm')]: {
-      backgroundImage: `url(${smallscreenbackground})`,
-      backgroundPosition: 'right top',
-      padding: 0,
-      marginBottom: '3rem'
+    marginBottom: '3rem',
+    [theme.breakpoints.up('md')]: {
+      backgroundImage: `url(${heroBg})`,
+      backgroundPosition: 'center',
+      marginBottom: '6rem',
+      padding: '4rem 0'
     }
   },
-  herotitle: {
-    [theme.breakpoints.down('sm')]: {
-      width: '80%'
+  heroTitle: {
+    width: '80%',
+    [theme.breakpoints.up('md')]: {
+      width: 'auto'
     }
   }
-});
+}));
 
-function HomeHero({ classes }) {
+function HomeHero(props) {
+  const classes = useStyles(props);
   const { toggleModal } = useToggleModal('portal');
+
   return (
     <Hero classes={{ root: classes.root }}>
       <Grid
@@ -58,7 +58,7 @@ function HomeHero({ classes }) {
         className={classes.heroContentGrid}
       >
         <HeroTitleGrid>
-          <HeroTitle classes={{ title: classes.herotitle }}>
+          <HeroTitle classes={{ title: classes.heroTitle }}>
             Discover the stories behind the data
           </HeroTitle>
 
@@ -76,8 +76,4 @@ function HomeHero({ classes }) {
   );
 }
 
-HomeHero.propTypes = {
-  classes: PropTypes.shape({}).isRequired
-};
-
-export default withStyles(styles)(HomeHero);
+export default HomeHero;

--- a/src/components/Hero/HomeHeroMap.js
+++ b/src/components/Hero/HomeHeroMap.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import map from '../../assets/images/bg/hero_map.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   verticalAlignText: {
     color: 'white',
     writingMode: 'vertical-lr',
@@ -33,19 +31,17 @@ const styles = theme => ({
     marginBottom: theme.spacing(8),
     height: '4rem'
   }
-});
+}));
 
-function HomeHeroMap({ classes }) {
+function HomeHeroMap(props) {
+  const classes = useStyles(props);
+
   return (
     <Grid
       xs={12}
-      sm={12}
       md={4}
-      lg={4}
-      xl={4}
       item
       container
-      direction="row"
       justify="flex-end"
       alignItems="center"
       className={classes.mapSection}
@@ -65,8 +61,4 @@ function HomeHeroMap({ classes }) {
   );
 }
 
-HomeHeroMap.propTypes = {
-  classes: PropTypes.shape({}).isRequired
-};
-
-export default withStyles(styles)(HomeHeroMap);
+export default HomeHeroMap;

--- a/src/components/Hero/ProfileHero/Profile.js
+++ b/src/components/Hero/ProfileHero/Profile.js
@@ -151,7 +151,7 @@ function Profile({
   return (
     <Hero classes={{ root: classes.root }} {...props}>
       <HeroTitleGrid
-        quater
+        quarter
         head2head={head2head}
         classes={{ titleTextGrid: classes.titleGrid }}
       >

--- a/src/components/Hero/TitleHero.js
+++ b/src/components/Hero/TitleHero.js
@@ -1,24 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 import Hero, { HeroTitle, HeroTitleGrid } from './Hero';
 
-const styles = {
+const useStyles = makeStyles(() => ({
   root: {
     flexGrow: 1,
     margin: '4rem 0'
-  },
-  titlegrid: {
-    alignItems: 'center'
   }
-};
+}));
 
-function TitleHero({ classes, children }) {
+function TitleHero({ children, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Hero classes={{ root: classes.root }}>
-      <HeroTitleGrid classes={{ titleTextGrid: classes.titlegrid }}>
+      <HeroTitleGrid>
         <HeroTitle>{children}</HeroTitle>
       </HeroTitleGrid>
     </Hero>
@@ -26,11 +25,10 @@ function TitleHero({ classes, children }) {
 }
 
 TitleHero.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired
 };
 
-export default withStyles(styles)(TitleHero);
+export default TitleHero;

--- a/src/components/Modal/ContactUs.js
+++ b/src/components/Modal/ContactUs.js
@@ -2,16 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  makeStyles,
+  ButtonBase,
   Grid,
-  Typography,
-  MenuList,
   MenuItem,
-  ButtonBase
+  MenuList,
+  Typography
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+
 import cross from '../../assets/images/icons/close.svg';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     color: 'white',
@@ -78,9 +79,11 @@ const styles = theme => ({
     marginTop: '1rem',
     opacity: 0.5
   }
-});
+}));
 
-function ContactUs({ classes, handleClose }) {
+function ContactUs({ handleClose, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Grid
       className={classes.root}
@@ -126,8 +129,7 @@ function ContactUs({ classes, handleClose }) {
 }
 
 ContactUs.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   handleClose: PropTypes.func.isRequired
 };
 
-export default withStyles(styles)(ContactUs);
+export default ContactUs;

--- a/src/components/Modal/PortalChooser.js
+++ b/src/components/Modal/PortalChooser.js
@@ -2,19 +2,21 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  makeStyles,
+  Button,
   Grid,
-  Typography,
   MenuList,
   MenuItem,
-  Button
+  Typography
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+
+import { AppContext } from '../../AppContext';
+import GetLocation from './GetLocation';
+
 import geolocate from '../../assets/images/icons/shape.svg';
 import cross from '../../assets/images/icons/close.svg';
-import GetLocation from './GetLocation';
-import { AppContext } from '../../AppContext';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   grid: {
     flexGrow: 1,
     width: '100%',
@@ -35,6 +37,9 @@ const styles = theme => ({
       color: '#e7e452'
     },
     [theme.breakpoints.up('md')]: {
+      paddingRight: '50px'
+    },
+    [theme.breakpoints.up('lg')]: {
       paddingRight: '150px'
     }
   },
@@ -42,10 +47,11 @@ const styles = theme => ({
     float: 'right'
   },
   listIndex: {
+    display: 'none',
     marginRight: '50px',
     width: '80px',
-    [theme.breakpoints.down('sm')]: {
-      display: 'none'
+    [theme.breakpoints.up('md')]: {
+      display: 'block'
     }
   },
   closeButton: {
@@ -60,14 +66,16 @@ const styles = theme => ({
     }
   },
   closeSpan: {
-    [theme.breakpoints.down('sm')]: {
-      display: 'none'
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'inline'
     }
   },
   closeImage: {
     marginLeft: theme.spacing(6),
-    [theme.breakpoints.down('sm')]: {
-      float: 'right'
+    float: 'right',
+    [theme.breakpoints.up('md')]: {
+      float: 'none'
     }
   },
   browseText: {
@@ -135,9 +143,10 @@ const styles = theme => ({
   locationHr: {
     marginTop: '1rem'
   }
-});
+}));
 
-function PortalChooser({ classes, children, countries, handleClose }) {
+function PortalChooser({ children, countries, handleClose, ...props }) {
+  const classes = useStyles(props);
   const {
     state: { selectedCountry }
   } = useContext(AppContext);
@@ -150,15 +159,7 @@ function PortalChooser({ classes, children, countries, handleClose }) {
       className={classes.grid}
     >
       {children}
-      <Grid
-        xs={12}
-        sm={12}
-        md={5}
-        lg={5}
-        xl={5}
-        item
-        className={classes.locationGrid}
-      >
+      <Grid xs={12} md={5} item className={classes.locationGrid}>
         <Typography
           component="div"
           variant="body2"
@@ -188,15 +189,7 @@ function PortalChooser({ classes, children, countries, handleClose }) {
           </Button>
         </Grid>
       </Grid>
-      <Grid
-        xs={12}
-        sm={12}
-        md={7}
-        lg={7}
-        xl={7}
-        item
-        className={classes.countryLocationGrid}
-      >
+      <Grid xs={12} md={7} item className={classes.countryLocationGrid}>
         <MenuList className={classes.countryList}>
           {Object.keys(countries).map((country, index) => (
             <MenuItem
@@ -223,7 +216,6 @@ function PortalChooser({ classes, children, countries, handleClose }) {
 }
 
 PortalChooser.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -236,4 +228,4 @@ PortalChooser.defaultProps = {
   children: null
 };
 
-export default withStyles(styles)(PortalChooser);
+export default PortalChooser;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withStyles } from '@material-ui/core/styles';
-
-import { Modal as MaterialModal } from '@material-ui/core';
+import { makeStyles, Modal as MaterialModal } from '@material-ui/core';
 
 import background from '../../assets/images/bg/background.png';
 
-const styles = {
+const useStyles = makeStyles(() => ({
   root: {
     flexGrow: 1,
     padding: 0,
@@ -20,9 +18,11 @@ const styles = {
     height: 'auto',
     width: '100vw'
   }
-};
+}));
 
-function Modal({ classes, children, isOpen, onEscapeKeyDown }) {
+function Modal({ children, isOpen, onEscapeKeyDown, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <MaterialModal
       hideBackdrop
@@ -36,7 +36,6 @@ function Modal({ classes, children, isOpen, onEscapeKeyDown }) {
 }
 
 Modal.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -49,4 +48,4 @@ Modal.defaultProps = {
   onEscapeKeyDown: () => {}
 };
 
-export default withStyles(styles)(Modal);
+export default Modal;

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+
+import { makeStyles, Grid } from '@material-ui/core';
 
 import A from './A';
 
@@ -11,13 +10,15 @@ import ancir from '../assets/images/logos/ancir.png';
 import africadrone from '../assets/images/logos/africa-drone.png';
 import oxpeckers from '../assets/images/logos/oxpeckers.png';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: theme.palette.secondary.light
   },
   layout: {
-    height: '14rem',
+    [theme.breakpoints.up('sm')]: {
+      height: '14rem'
+    },
     [theme.breakpoints.up('md')]: {
       maxWidth: '81.3571429rem',
       margin: '0 auto',
@@ -35,14 +36,22 @@ const styles = theme => ({
     }
   },
   imageGrid: {
-    padding: '1.143remrem',
+    textAlign: 'center',
+    width: '100%',
+    padding: '1.143rem',
+    [theme.breakpoints.up('sm')]: {
+      textAlign: 'left',
+      width: 'auto'
+    },
     [theme.breakpoints.up('md')]: {
       padding: '2.286rem 1.143rem'
     }
   }
-});
+}));
 
-function Partners({ classes }) {
+function Partners(props) {
+  const classes = useStyles(props);
+
   return (
     <Grid className={classes.root}>
       <Grid
@@ -85,8 +94,4 @@ function Partners({ classes }) {
   );
 }
 
-Partners.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(Partners);
+export default Partners;

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -13,7 +13,11 @@ import oxpeckers from '../assets/images/logos/oxpeckers.png';
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
-    backgroundColor: theme.palette.secondary.light
+    backgroundColor: theme.palette.secondary.light,
+    padding: '1.5rem 0',
+    [theme.breakpoints.up('sm')]: {
+      padding: 0
+    }
   },
   layout: {
     [theme.breakpoints.up('sm')]: {
@@ -30,21 +34,24 @@ const useStyles = makeStyles(theme => ({
   img: {
     maxHeight: '4.288rem',
     maxWidth: '30vw',
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('sm')]: {
       width: 'auto',
+      maxWidth: '15vw'
+    },
+    [theme.breakpoints.up('lg')]: {
       maxWidth: '11.423rem'
     }
   },
   imageGrid: {
     textAlign: 'center',
     width: '100%',
-    padding: '1.143rem',
+    padding: '0.75rem',
     [theme.breakpoints.up('sm')]: {
       textAlign: 'left',
       width: 'auto'
     },
-    [theme.breakpoints.up('md')]: {
-      padding: '2.286rem 1.143rem'
+    [theme.breakpoints.up('lg')]: {
+      padding: '2.286rem 2.643rem'
     }
   }
 }));

--- a/src/components/ProfileReleases/index.js
+++ b/src/components/ProfileReleases/index.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import A from '../A';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: 'white',
@@ -84,9 +82,11 @@ const styles = theme => ({
     width: '9.375rem',
     maxWidth: '9.375rem'
   }
-});
+}));
 
-function ProfileRelease({ classes }) {
+function ProfileRelease(props) {
+  const classes = useStyles(props);
+
   const citationLink = link => (
     <A className={classes.link} href={link}>
       {link}
@@ -140,8 +140,4 @@ function ProfileRelease({ classes }) {
   );
 }
 
-ProfileRelease.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(ProfileRelease);
+export default ProfileRelease;

--- a/src/components/Search/SearchBar.js
+++ b/src/components/Search/SearchBar.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
-import InputBase from '@material-ui/core/InputBase';
-import { Grid, IconButton } from '@material-ui/core';
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
+
+import {
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+  Grid,
+  IconButton,
+  InputBase
+} from '@material-ui/core';
+
 import back from '../../assets/images/icons/back.svg';
 import search from '../../assets/images/icons/location.svg';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     [theme.breakpoints.down('sm')]: {
@@ -56,11 +62,10 @@ const styles = theme => ({
       padding: '47px'
     }
   }
-});
+}));
 
 function SearchBar({
   primary,
-  classes,
   placeholder,
   value,
   width,
@@ -68,12 +73,17 @@ function SearchBar({
   handleIconClick,
   handleValueChange,
   isComparisonSearch,
-  autoFocus
+  autoFocus,
+  ...props
 }) {
+  const classes = useStyles(props);
+  const theme = useTheme();
+  const isMdAndUp = useMediaQuery(theme.breakpoints.up('md'));
   let searchBarIcon = icon;
   if (!searchBarIcon) {
-    searchBarIcon = isWidthUp('md', width) ? back : search;
+    searchBarIcon = isMdAndUp ? back : search;
   }
+
   return (
     <Grid
       container
@@ -117,7 +127,6 @@ function SearchBar({
 }
 
 SearchBar.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   handleValueChange: PropTypes.func.isRequired,
   icon: PropTypes.string,
   handleIconClick: PropTypes.func,
@@ -138,4 +147,4 @@ SearchBar.defaultProps = {
   icon: null
 };
 
-export default withWidth()(withStyles(styles)(SearchBar));
+export default SearchBar;

--- a/src/components/Search/SearchResults.js
+++ b/src/components/Search/SearchResults.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Grid, List, ListItem, Typography } from '@material-ui/core';
+import {
+  makeStyles,
+  Grid,
+  List,
+  ListItem,
+  Typography
+} from '@material-ui/core';
 
-import { withStyles } from '@material-ui/core/styles';
-
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     fontSize: '14px',
@@ -81,7 +85,7 @@ const styles = theme => ({
     fontSize: '16px',
     fontWeight: '400'
   }
-});
+}));
 
 const maxResults = 6;
 
@@ -98,12 +102,14 @@ function renderHref(codeType, result, thisGeoId, isComparisonSearch) {
 }
 
 function SearchResults({
-  classes,
   codeType,
   results,
   isComparisonSearch,
-  thisGeoId
+  thisGeoId,
+  ...props
 }) {
+  const classes = useStyles(props);
+
   return (
     <Grid
       container
@@ -111,7 +117,7 @@ function SearchResults({
         [classes.rootDropdown]: isComparisonSearch
       })}
     >
-      <Grid container direction="row" justify="flex-end">
+      <Grid item xs={12} container justify="flex-end">
         <List className={classes.list}>
           {results.slice(0, maxResults).map(result => (
             <ListItem
@@ -124,7 +130,7 @@ function SearchResults({
               component="a"
               href={renderHref(codeType, result, thisGeoId, isComparisonSearch)}
             >
-              <Grid container direction="row" alignItems="baseline">
+              <Grid container alignItems="baseline">
                 <Typography
                   className={classNames(classes.level, {
                     [classes.levelDropdown]: isComparisonSearch
@@ -153,7 +159,6 @@ function SearchResults({
 }
 
 SearchResults.propTypes = {
-  classes: PropTypes.shape().isRequired,
   codeType: PropTypes.string.isRequired,
   results: PropTypes.arrayOf(PropTypes.object).isRequired,
   thisGeoId: PropTypes.string,
@@ -164,4 +169,4 @@ SearchResults.defaultProps = {
   thisGeoId: ''
 };
 
-export default withStyles(styles)(SearchResults);
+export default SearchResults;

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,12 +1,11 @@
 import React from 'react';
-
 import { PropTypes } from 'prop-types';
-import { Typography, Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import classNames from 'classnames';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     padding: '2rem',
@@ -26,10 +25,22 @@ const styles = theme => ({
   },
   gridMargin: {
     marginBottom: '1.4286rem'
-  }
-});
+  },
+  subtitle: {},
+  content: {}
+}));
 
-function Section({ id, classes, light, title, subtitle, children }) {
+function Section({
+  children,
+  id,
+  light,
+  title,
+  subtitle,
+  titleVariant,
+  ...props
+}) {
+  const classes = useStyles(props);
+
   return (
     <div
       id={id}
@@ -37,10 +48,12 @@ function Section({ id, classes, light, title, subtitle, children }) {
     >
       <Grid container className={classes.wrapper}>
         <Grid item xs={12} md={4} className={classes.gridMargin}>
-          <Typography variant="h3">{title}</Typography>
-          <Typography variant="subtitle1">{subtitle}</Typography>
+          <Typography variant={titleVariant}>{title}</Typography>
+          <Typography variant="subtitle1" className={classes.subtitle}>
+            {subtitle}
+          </Typography>
         </Grid>
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12} md={8} className={classes.content}>
           <div>{children}</div>
         </Grid>
       </Grid>
@@ -51,8 +64,8 @@ function Section({ id, classes, light, title, subtitle, children }) {
 Section.propTypes = {
   id: PropTypes.string,
   light: PropTypes.bool,
-  classes: PropTypes.shape({}).isRequired,
   title: PropTypes.string.isRequired,
+  titleVariant: PropTypes.string,
   subtitle: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
@@ -61,9 +74,10 @@ Section.propTypes = {
 };
 
 Section.defaultProps = {
+  children: null,
   id: undefined,
   light: false,
-  children: null
+  titleVariant: 'h3'
 };
 
-export default withStyles(styles)(Section);
+export default Section;

--- a/src/components/Showcase/StoryCard.js
+++ b/src/components/Showcase/StoryCard.js
@@ -2,16 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Typography,
+  makeStyles,
   Card,
   CardActionArea,
-  CardMedia,
   CardContent,
-  Grid
+  CardMedia,
+  Grid,
+  Typography
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     minHeight: '20rem',
     height: '100%',
@@ -65,9 +65,10 @@ const styles = theme => ({
     webkitFilter: 'brightness(40%)' /* Safari 6.0 - 9.0 */,
     filter: 'brightness(40%)'
   }
-});
+}));
 
-function StoryCard({ story, classes }) {
+function StoryCard({ story, ...props }) {
+  const classes = useStyles(props);
   const { mediaSrc, date, title, brief, link, media } = story;
 
   return (
@@ -120,8 +121,7 @@ function StoryCard({ story, classes }) {
 }
 
 StoryCard.propTypes = {
-  classes: PropTypes.shape().isRequired,
   story: PropTypes.shape().isRequired
 };
 
-export default withStyles(styles)(StoryCard);
+export default StoryCard;

--- a/src/components/Showcase/StoryList.js
+++ b/src/components/Showcase/StoryList.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withWidth, { isWidthDown } from '@material-ui/core/withWidth';
 
-import { Grid, GridList, GridListTile } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  useMediaQuery,
+  Grid,
+  GridList,
+  GridListTile
+} from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
 
 import StoryCard from './StoryCard';
 
-const styles = () => ({
+const useStyles = makeStyles(() => ({
   root: {
     flexGrow: 1,
     /**
@@ -23,26 +28,23 @@ const styles = () => ({
   },
   gridList: {
     flexWrap: 'nowrap',
-    // TODO(nyokabi): Material-ui documentation for Grid list componenet
+    // TODO(nyokabi): Material-ui documentation for Grid list component
     //                Promote the list into its own layer on Chrome. This cost
     //                memory but helps keeping high FPS.
     transform: 'translateZ(0)',
     height: '100%',
     margin: '0 !important'
   }
-});
+}));
 
-function StoryList({ classes, storyData, width }) {
-  // TODO(kilemensi): GridListTile computes the size of item and sets it using
-  //                  style. This means we can't use classes since element
-  //                  style has higher preference. Hence the use of style here.
-  //                  We need to match exact size of StoryCard so we don't end
-  //                  up with a lot of spaces around StoryCard.
+function StoryList({ storyData, width, ...props }) {
+  const classes = useStyles(props);
+  const theme = useTheme();
   let cards = 4;
-  if (isWidthDown('md', width)) {
-    cards = 3;
+  if (useMediaQuery(theme.breakpoints.down('md'))) {
+    cards = 2;
   }
-  if (isWidthDown('sm', width)) {
+  if (useMediaQuery(theme.breakpoints.down('sm'))) {
     cards = 1;
   }
 
@@ -65,9 +67,8 @@ function StoryList({ classes, storyData, width }) {
 }
 
 StoryList.propTypes = {
-  classes: PropTypes.shape().isRequired,
   storyData: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   width: PropTypes.string.isRequired
 };
 
-export default withWidth()(withStyles(styles)(StoryList));
+export default StoryList;

--- a/src/components/Showcase/index.js
+++ b/src/components/Showcase/index.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Typography } from '@material-ui/core';
-
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, Typography } from '@material-ui/core';
 
 import StoryList from './StoryList';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   showCaseContainer: {
     backgroundColor: 'white',
     display: 'inline-block',
@@ -18,8 +16,11 @@ const styles = theme => ({
     padding: '3.1875rem 1.875rem',
     [theme.breakpoints.up('md')]: {
       padding: '3.1875rem 0',
-      width: '80%',
+      width: '75%',
       float: 'right'
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '80%'
     }
   },
   headline: {
@@ -39,15 +40,21 @@ const styles = theme => ({
   headlineDescription: {
     textAlign: 'left'
   }
-});
+}));
 
-function Showcase({ classes, showcaseStories, dominion: { selectedCountry } }) {
+function Showcase({
+  showcaseStories,
+  dominion: { selectedCountry },
+  ...props
+}) {
+  const classes = useStyles(props);
   let stories = showcaseStories;
   if (selectedCountry) {
     stories = showcaseStories.filter(
       story => story.country === selectedCountry.code
     );
   }
+
   return (
     <div className={classes.showCaseContainer} id="showcase">
       <Grid
@@ -87,11 +94,10 @@ function Showcase({ classes, showcaseStories, dominion: { selectedCountry } }) {
 }
 
 Showcase.propTypes = {
-  classes: PropTypes.shape({}).isRequired,
   dominion: PropTypes.shape({
     selectedCountry: PropTypes.shape({})
   }).isRequired,
   showcaseStories: PropTypes.arrayOf(PropTypes.shape({})).isRequired
 };
 
-export default withStyles(styles)(Showcase);
+export default Showcase;

--- a/src/components/Video/Player.js
+++ b/src/components/Video/Player.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 
-import { Grid, IconButton } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid, IconButton } from '@material-ui/core';
 
 import IFrame from '../IFrame';
 import Sources from './Sources';
@@ -11,7 +9,7 @@ import Thumbnail from './Thumbnail';
 import back from '../../assets/images/icons/back.svg';
 import useToggleModal from '../../useToggleModal';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: 'black',
@@ -57,9 +55,10 @@ const styles = theme => ({
       marginLeft: '2.5rem'
     }
   }
-});
+}));
 
-function Player({ classes }) {
+function Player(props) {
+  const classes = useStyles(props);
   const [videoId, setVideoId] = useState((Sources[0] && Sources[0].id) || null);
   const { toggleModal } = useToggleModal('video');
 
@@ -124,8 +123,4 @@ function Player({ classes }) {
   );
 }
 
-Player.propTypes = {
-  classes: PropTypes.shape().isRequired
-};
-
-export default withStyles(styles)(Player);
+export default Player;

--- a/src/components/Video/Thumbnail.js
+++ b/src/components/Video/Thumbnail.js
@@ -2,12 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { Button, Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Button, Grid, Typography } from '@material-ui/core';
 
 import { PlayArrowOutlined, PlayArrow } from '@material-ui/icons';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',
@@ -57,9 +56,10 @@ const styles = theme => ({
     lineHeight: 1.14,
     letterSpacing: '0.4px'
   }
-});
+}));
 
-function Thumbnail({ classes, isSelected, onClick, videoId, videoTitle }) {
+function Thumbnail({ isSelected, onClick, videoId, videoTitle, ...props }) {
+  const classes = useStyles(props);
   const { overlay, overlaySelected } = classes;
   const rootOverlay = classNames(overlay, { [overlaySelected]: isSelected });
 
@@ -96,7 +96,6 @@ function Thumbnail({ classes, isSelected, onClick, videoId, videoTitle }) {
 }
 
 Thumbnail.propTypes = {
-  classes: PropTypes.shape().isRequired,
   isSelected: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   videoId: PropTypes.string.isRequired,
@@ -107,4 +106,4 @@ Thumbnail.defaultProps = {
   isSelected: false
 };
 
-export default withStyles(styles)(Thumbnail);
+export default Thumbnail;

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, Button, Grid, Typography } from '@material-ui/core';
 import PlayArrow from '@material-ui/icons/PlayArrow';
 
 import PlayerModal from './PlayerModal';
@@ -10,7 +9,7 @@ import PlayerModal from './PlayerModal';
 import background from '../../assets/images/hero-image-1.png';
 import useToggleModal from '../../useToggleModal';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundImage: `url(${background})`,
@@ -52,10 +51,12 @@ const styles = theme => ({
   modal: {
     backgroundColor: 'rgba(0, 0, 0, 0.8)'
   }
-});
+}));
 
-function Video({ classes, dominion }) {
+function Video({ dominion, ...props }) {
+  const classes = useStyles(props);
   const { open, toggleModal } = useToggleModal('video');
+
   return (
     <Grid
       container
@@ -103,8 +104,7 @@ function Video({ classes, dominion }) {
 }
 
 Video.propTypes = {
-  classes: PropTypes.shape().isRequired,
   dominion: PropTypes.shape({}).isRequired
 };
 
-export default withStyles(styles)(Video);
+export default Video;


### PR DESCRIPTION
## Description

This PR improve mobile responsive of the site by: 

- Changing desktop mode of the site to start at `768px` by changing `md` `breakpoint` value,
- At `xs`, components should be aligned in row, and
- Review all components to make sure they behave correctly _after_ the above changes.
  - [x] `AboutCountry`,
  - [x] `AboutDominion`,
  - [x] `CountryPartners`,
  - [x] `Documents & Datasets`
  - [x] `Footer`,
  - [x] `Hero`,
  - [x] `Header`,
  - [x] `Modal`,
  - [x] `Partners`,
  - [x] `ProfileReleases`,
  - [x] `Search`,
  - [x] `Video`, and
  - [x] `Resources` page components.

Closes #28 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

### Mobile

![S2](https://user-images.githubusercontent.com/1779590/65239207-2257f100-dae7-11e9-9c4a-ac2610d26dff.jpg)

### iPad

![S1](https://user-images.githubusercontent.com/1779590/65239225-297eff00-dae7-11e9-855c-2224b9f57c2d.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
