### PR TITLE
Fix commitChartDefinition when nothing has been staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "^1.16.1"
   },
   "scripts": {
-    "commitChartDefinitions": "git add src/data/charts.json && git commit -m 'updated chart ids' && git push",
+    "commitChartDefinitions": "git add src/data/charts.json && (git diff-index --quiet HEAD || (git commit -m 'updated chart ids' && git push))",
     "applyIdsToChartDefinitions": "node scripts/chartsDefinitionsApplyUniqueId.js",
     "prestart": "yarn applyIdsToChartDefinitions",
     "start": "react-scripts start",


### PR DESCRIPTION
## Description

Only commit and push if there were changes

Handling empty commits: https://stackoverflow.com/questions/8123674/how-to-git-commit-nothing-without-an-error
Multiple bash operators: https://unix.stackexchange.com/questions/290146/multiple-logical-operators-a-b-c-and-syntax-error-near-unexpected-t

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots

![Screenshot from 2019-09-19 14-33-26](https://user-images.githubusercontent.com/1779590/65240797-c5f6d080-daea-11e9-9292-6eb080f4d0b5.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
